### PR TITLE
fix: output of object reader not sortable lexicographically

### DIFF
--- a/reflect/ObjectReader.go
+++ b/reflect/ObjectReader.go
@@ -1,8 +1,8 @@
 package reflect
 
 import (
+	"fmt"
 	refl "reflect"
-	"strconv"
 	"strings"
 
 	"github.com/pip-services3-go/pip-services3-commons-go/convert"
@@ -22,15 +22,15 @@ PropertyReflector
 
 Example:
  myObj := MyObject{}
- 
+
  properties := ObjectReader.GetPropertyNames()
  ObjectReader.HasProperty(myObj, "myProperty")
  value := PropertyReflector.GetProperty(myObj, "myProperty")
- 
+
  myMap := { key1: 123, key2: "ABC" }
  ObjectReader.HasProperty(myMap, "key1")
  value := ObjectReader.GetProperty(myMap, "key1")
- 
+
  myArray := [1, 2, 3]
  ObjectReader.HasProperty(myArrat, "0")
  value := ObjectReader.GetProperty(myArray, "0")
@@ -156,8 +156,9 @@ func (c *TObjectReader) GetPropertyNames(obj interface{}) []string {
 	}
 
 	if val.Kind() == refl.Slice || val.Kind() == refl.Array {
+		strFmt := c.GetStrIndexFormat(val.Len())
 		for index := 0; index < val.Len(); index++ {
-			properties = append(properties, strconv.Itoa(index))
+			properties = append(properties, fmt.Sprintf(strFmt, index))
 		}
 		return properties
 	}
@@ -190,11 +191,22 @@ func (c *TObjectReader) GetProperties(obj interface{}) map[string]interface{} {
 	}
 
 	if val.Kind() == refl.Slice || val.Kind() == refl.Array {
+		strFmt := c.GetStrIndexFormat(val.Len())
 		for index := 0; index < val.Len(); index++ {
-			values[strconv.Itoa(index)] = val.Index(index).Interface()
+			values[fmt.Sprintf(strFmt, index)] = val.Index(index).Interface()
 		}
 		return values
 	}
 
 	return PropertyReflector.GetProperties(obj)
+}
+
+func (c *TObjectReader) GetStrIndexFormat(len int) string {
+	count := 0
+	for len > 0 {
+		count++
+		len = len / 10
+	}
+
+	return fmt.Sprintf("%%0%dd", count)
 }


### PR DESCRIPTION
When taken with the change here:  https://github.com/pip-services3-go/pip-services3-container-go/commit/948e1714e1481129bb8aa1ba7bfa08f411509dbc#diff-5bf521221af3258a684cbfcf0b35feee96d4230915091965e2098bc26b37906a which is geared towards keeping the dependencies declared in the config.yml in order, this means that the output of the GetProperties and GetPropertyNames needs to be sortable lexicographically -- meaning for integers we need to prepend them with a number of 0s depending on how long the properties list is.  Instead of "1", "2", ... "10" which will sort as "1", "10", "2", ... we want "01", "02", ... "10" which will sort in the correct order.